### PR TITLE
fix: handle date range stats without unsupported SQLite function

### DIFF
--- a/src/database/DatabaseManager.js
+++ b/src/database/DatabaseManager.js
@@ -982,11 +982,14 @@ class DatabaseManager {
                 
                 this.get(`
                     SELECT SUM(
-                        GREATEST(1, julianday(?) - julianday(cir.check_in_date))
+                        CASE
+                            WHEN (julianday(?) - julianday(cir.check_in_date)) < 1 THEN 1
+                            ELSE (julianday(?) - julianday(cir.check_in_date))
+                        END
                     ) as total_days
                     FROM check_in_records cir
                     WHERE date(cir.check_in_date) BETWEEN date(?) AND date(?)
-                `, [endDate, startDate, endDate])
+                `, [endDate, endDate, startDate, endDate])
             ]);
 
             // 按月统计趋势


### PR DESCRIPTION
## Summary
- replace unsupported SQLite `GREATEST` with CASE logic in date-range family service stats query

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a7f2b66cc88333a97bc47305088c8a