### PR TITLE
Use month-only inputs for date range selection

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1123,11 +1123,11 @@
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
               <div>
                 <label class="block text-sm font-medium text-[var(--text-secondary)] mb-2">开始日期</label>
-                <input type="date" id="fsDateRangeStart" class="w-full px-3 py-2 border border-gray-200 rounded-lg focus:border-[var(--brand-primary)] focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-opacity-20">
+                <input type="month" id="fsDateRangeStart" class="w-full px-3 py-2 border border-gray-200 rounded-lg focus:border-[var(--brand-primary)] focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-opacity-20">
               </div>
               <div>
                 <label class="block text-sm font-medium text-[var(--text-secondary)] mb-2">结束日期</label>
-                <input type="date" id="fsDateRangeEnd" class="w-full px-3 py-2 border border-gray-200 rounded-lg focus:border-[var(--brand-primary)] focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-opacity-20">
+                <input type="month" id="fsDateRangeEnd" class="w-full px-3 py-2 border border-gray-200 rounded-lg focus:border-[var(--brand-primary)] focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-opacity-20">
               </div>
               <div>
                 <button id="fsApplyDateRange" class="w-full btn btn-primary">查询统计</button>

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -2944,19 +2944,23 @@ class PatientApp {
     bindFamilyServiceEvents(stats) {
         // 时间范围查询
         document.getElementById('fsApplyDateRange').addEventListener('click', async () => {
-            const startDate = document.getElementById('fsDateRangeStart').value;
-            const endDate = document.getElementById('fsDateRangeEnd').value;
-            
-            if (!startDate || !endDate) {
+            const startMonth = document.getElementById('fsDateRangeStart').value;
+            const endMonth = document.getElementById('fsDateRangeEnd').value;
+
+            if (!startMonth || !endMonth) {
                 alert('请选择开始和结束日期');
                 return;
             }
-            
+
+            const startDate = `${startMonth}-01`;
+            const [endYear, endMonthNum] = endMonth.split('-').map(Number);
+            const endDate = new Date(endYear, endMonthNum, 0).toISOString().split('T')[0];
+
             if (new Date(startDate) > new Date(endDate)) {
                 alert('开始日期不能晚于结束日期');
                 return;
             }
-            
+
             try {
                 const rangeStats = await window.electronAPI.familyService.getStatsByDateRange({ startDate, endDate });
                 this.displayDateRangeResults(rangeStats);
@@ -2996,8 +3000,8 @@ class PatientApp {
         document.getElementById('fsRangeRecords').textContent = rangeStats.totalRecords;
         document.getElementById('fsRangeFamilies').textContent = rangeStats.totalFamilies;
         document.getElementById('fsRangeServiceDays').textContent = rangeStats.totalServiceDays;
-        document.getElementById('fsRangePeriod').textContent = 
-            `${rangeStats.dateRange.startDate} 至 ${rangeStats.dateRange.endDate}`;
+        document.getElementById('fsRangePeriod').textContent =
+            `${rangeStats.dateRange.startDate.slice(0, 7)} 至 ${rangeStats.dateRange.endDate.slice(0, 7)}`;
         
         document.getElementById('fsDateRangeResults').classList.remove('hidden');
     }


### PR DESCRIPTION
## Summary
- change date range inputs to month-only selectors
- derive full date range from selected months
- show selected months in range summary

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a7f40b2378833395fa1176a0368e0c