### PR TITLE
feat: add stats link to patient list card

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -486,11 +486,30 @@
               </div>
               <div class="p-6">
                 <p class="text-[var(--text-secondary)] mb-4">查看和管理患儿基本信息、入住记录、医疗档案等核心数据</p>
-                <div class="flex items-center justify-between">
+                <div class="flex items-center justify-between mb-4">
                   <span class="text-sm text-[var(--brand-primary)] font-medium">立即访问</span>
                   <svg class="w-4 h-4 text-[var(--brand-primary)] transform group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                   </svg>
+                </div>
+                <!-- 入住信息子功能 -->
+                <div class="border-t border-[var(--border-primary)] pt-4">
+                  <button onclick="app.navigateToStatistics(); event.stopPropagation();" class="w-full text-left p-2 rounded-lg hover:bg-[var(--bg-tertiary)] transition-colors group/sub">
+                    <div class="flex items-center gap-3">
+                      <div class="w-8 h-8 bg-[var(--brand-bg)] rounded-lg flex items-center justify-center">
+                        <svg class="w-4 h-4 text-[var(--brand-primary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                        </svg>
+                      </div>
+                      <div class="flex-1">
+                        <div class="text-sm font-medium text-[var(--text-primary)]">统计分析</div>
+                        <div class="text-xs text-[var(--text-secondary)]">年龄、性别、趋势统计</div>
+                      </div>
+                      <svg class="w-3 h-3 text-[var(--text-muted)] group-hover/sub:text-[var(--brand-primary)] transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                      </svg>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add statistical analysis quick link under patient list card
- allow direct navigation to overall statistics page

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fafa4eb48333960caba21c0cc60b