### PR TITLE
feat: add care beneficiary importer and schema

### DIFF
--- a/database-schema.sql
+++ b/database-schema.sql
@@ -108,3 +108,48 @@ CREATE TABLE IF NOT EXISTS family_service_records (
 -- 家庭服务索引
 CREATE INDEX IF NOT EXISTS idx_fsr_year_month ON family_service_records(year_month);
 CREATE INDEX IF NOT EXISTS idx_fsr_year ON family_service_records(strftime('%Y', year_month));
+
+-- 关怀服务受益记录表
+CREATE TABLE IF NOT EXISTS care_beneficiary_records (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sequence_number TEXT,
+    year INTEGER,
+    month INTEGER,
+    service_center TEXT,
+    project_domain TEXT,
+    activity_type TEXT,
+    activity_date TEXT,
+    activity_name TEXT,
+    beneficiary_group TEXT,
+    reporter TEXT,
+    report_date TEXT,
+    adult_male INTEGER DEFAULT 0,
+    adult_female INTEGER DEFAULT 0,
+    adult_total INTEGER DEFAULT 0,
+    child_male INTEGER DEFAULT 0,
+    child_female INTEGER DEFAULT 0,
+    child_total INTEGER DEFAULT 0,
+    total_beneficiaries INTEGER DEFAULT 0,
+    volunteer_child_count INTEGER DEFAULT 0,
+    volunteer_child_hours REAL DEFAULT 0,
+    volunteer_parent_count INTEGER DEFAULT 0,
+    volunteer_parent_hours REAL DEFAULT 0,
+    volunteer_student_count INTEGER DEFAULT 0,
+    volunteer_student_hours REAL DEFAULT 0,
+    volunteer_teacher_count INTEGER DEFAULT 0,
+    volunteer_teacher_hours REAL DEFAULT 0,
+    volunteer_social_count INTEGER DEFAULT 0,
+    volunteer_social_hours REAL DEFAULT 0,
+    volunteer_total_count INTEGER DEFAULT 0,
+    volunteer_total_hours REAL DEFAULT 0,
+    benefit_adult_times INTEGER DEFAULT 0,
+    benefit_child_times INTEGER DEFAULT 0,
+    benefit_total_times INTEGER DEFAULT 0,
+    notes TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 关怀服务索引
+CREATE INDEX IF NOT EXISTS idx_cbr_year_month ON care_beneficiary_records(year, month);
+CREATE INDEX IF NOT EXISTS idx_cbr_service_center ON care_beneficiary_records(service_center);

--- a/src/services/CareBeneficiaryImporter.js
+++ b/src/services/CareBeneficiaryImporter.js
@@ -1,0 +1,136 @@
+const XLSX = require('xlsx');
+
+class CareBeneficiaryImporter {
+    constructor(databaseManager) {
+        this.db = databaseManager;
+        this.tableName = 'care_beneficiary_records';
+        this.sheetName = 'Sheet1';
+    }
+
+    parseNumber(value) {
+        if (value === null || value === undefined || value === '') {
+            return 0;
+        }
+        const num = parseFloat(value);
+        return isNaN(num) ? 0 : num;
+    }
+
+    parseDate(value) {
+        if (!value) return null;
+        if (typeof value === 'number') {
+            const date = XLSX.SSF.parse_date_code(value);
+            if (!date) return null;
+            return new Date(Date.UTC(date.y, date.m - 1, date.d));
+        }
+        const timestamp = Date.parse(value);
+        return isNaN(timestamp) ? null : new Date(timestamp);
+    }
+
+    async importFromExcel(filePath) {
+        const workbook = XLSX.readFile(filePath);
+        const worksheet = workbook.Sheets[this.sheetName];
+        const raw = XLSX.utils.sheet_to_json(worksheet, {
+            header: 1,
+            defval: null,
+            blankrows: false
+        });
+
+        if (raw.length < 4) {
+            throw new Error('Excel 文件格式不正确');
+        }
+
+        let imported = 0;
+        for (let i = 4; i < raw.length; i++) {
+            const row = raw[i] || [];
+            if (row.every(cell => cell === null || cell === undefined || cell === '')) {
+                continue;
+            }
+
+            const record = {
+                sequenceNumber: (row[0] || '').toString().trim(),
+                year: this.parseNumber(row[1]),
+                month: this.parseNumber(row[2]),
+                serviceCenter: (row[3] || '').toString().trim(),
+                projectDomain: (row[4] || row[35] || '').toString().trim(),
+                activityType: (row[5] || row[36] || '').toString().trim(),
+                activityDate: this.parseDate(row[6]),
+                activityName: (row[7] || '').toString().trim(),
+                beneficiaryGroup: (row[8] || '').toString().trim(),
+                reporter: (row[9] || '').toString().trim(),
+                reportDate: this.parseDate(row[10]),
+                adultMale: this.parseNumber(row[11]),
+                adultFemale: this.parseNumber(row[12]),
+                adultTotal: this.parseNumber(row[13]),
+                childMale: this.parseNumber(row[14]),
+                childFemale: this.parseNumber(row[15]),
+                childTotal: this.parseNumber(row[16]),
+                totalBeneficiaries: this.parseNumber(row[17]),
+                volunteerChildCount: this.parseNumber(row[18]),
+                volunteerChildHours: this.parseNumber(row[19]),
+                volunteerParentCount: this.parseNumber(row[20]),
+                volunteerParentHours: this.parseNumber(row[21]),
+                volunteerStudentCount: this.parseNumber(row[22]),
+                volunteerStudentHours: this.parseNumber(row[23]),
+                volunteerTeacherCount: this.parseNumber(row[24]),
+                volunteerTeacherHours: this.parseNumber(row[25]),
+                volunteerSocialCount: this.parseNumber(row[26]),
+                volunteerSocialHours: this.parseNumber(row[27]),
+                volunteerTotalCount: this.parseNumber(row[28]),
+                volunteerTotalHours: this.parseNumber(row[29]),
+                benefitAdultTimes: this.parseNumber(row[30]),
+                benefitChildTimes: this.parseNumber(row[31]),
+                benefitTotalTimes: this.parseNumber(row[32]),
+                notes: (row[33] || '').toString().trim()
+            };
+
+            const cols = [
+                'sequence_number','year','month','service_center','project_domain','activity_type','activity_date','activity_name','beneficiary_group','reporter','report_date','adult_male','adult_female','adult_total','child_male','child_female','child_total','total_beneficiaries','volunteer_child_count','volunteer_child_hours','volunteer_parent_count','volunteer_parent_hours','volunteer_student_count','volunteer_student_hours','volunteer_teacher_count','volunteer_teacher_hours','volunteer_social_count','volunteer_social_hours','volunteer_total_count','volunteer_total_hours','benefit_adult_times','benefit_child_times','benefit_total_times','notes'];
+
+            const values = [
+                record.sequenceNumber,
+                record.year,
+                record.month,
+                record.serviceCenter,
+                record.projectDomain,
+                record.activityType,
+                record.activityDate ? record.activityDate.toISOString().split('T')[0] : null,
+                record.activityName,
+                record.beneficiaryGroup,
+                record.reporter,
+                record.reportDate ? record.reportDate.toISOString().split('T')[0] : null,
+                record.adultMale,
+                record.adultFemale,
+                record.adultTotal,
+                record.childMale,
+                record.childFemale,
+                record.childTotal,
+                record.totalBeneficiaries,
+                record.volunteerChildCount,
+                record.volunteerChildHours,
+                record.volunteerParentCount,
+                record.volunteerParentHours,
+                record.volunteerStudentCount,
+                record.volunteerStudentHours,
+                record.volunteerTeacherCount,
+                record.volunteerTeacherHours,
+                record.volunteerSocialCount,
+                record.volunteerSocialHours,
+                record.volunteerTotalCount,
+                record.volunteerTotalHours,
+                record.benefitAdultTimes,
+                record.benefitChildTimes,
+                record.benefitTotalTimes,
+                record.notes
+            ];
+
+            const placeholders = cols.map(() => '?').join(',');
+            const sql = `INSERT INTO ${this.tableName} (${cols.join(',')}) VALUES (${placeholders})`;
+            await this.db.run(sql, values);
+            imported++;
+        }
+
+        return { imported };
+    }
+}
+
+module.exports = CareBeneficiaryImporter;

--- a/src/services/CareBeneficiaryManager.js
+++ b/src/services/CareBeneficiaryManager.js
@@ -1,0 +1,42 @@
+const CareBeneficiaryImporter = require('./CareBeneficiaryImporter');
+
+class CareBeneficiaryManager {
+    constructor(databaseManager) {
+        this.db = databaseManager;
+        this.importer = new CareBeneficiaryImporter(databaseManager);
+        this.tableName = 'care_beneficiary_records';
+    }
+
+    async importFromExcel(filePath) {
+        return await this.importer.importFromExcel(filePath);
+    }
+
+    async getRecords(filters = {}, pagination = {}) {
+        let sql = `SELECT * FROM ${this.tableName} WHERE 1=1`;
+        const params = [];
+
+        if (filters.year) {
+            sql += ' AND year = ?';
+            params.push(filters.year);
+        }
+        if (filters.month) {
+            sql += ' AND month = ?';
+            params.push(filters.month);
+        }
+        if (filters.serviceCenter) {
+            sql += ' AND service_center LIKE ?';
+            params.push(`%${filters.serviceCenter}%`);
+        }
+
+        sql += ' ORDER BY year DESC, month DESC';
+
+        if (pagination.limit) {
+            sql += ' LIMIT ? OFFSET ?';
+            params.push(pagination.limit, pagination.offset || 0);
+        }
+
+        return await this.db.all(sql, params);
+    }
+}
+
+module.exports = CareBeneficiaryManager;


### PR DESCRIPTION
## Summary
- add database schema and ensure logic for care beneficiary records
- implement CareBeneficiaryImporter to load 2024.xls data
- provide CareBeneficiaryManager for querying records

## Testing
- `npm test -- --passWithNoTests`
- `node -e "const DatabaseManager=require('./src/database/DatabaseManager');const CareBeneficiaryManager=require('./src/services/CareBeneficiaryManager');(async()=>{const db=new DatabaseManager();await db.initialize();const mgr=new CareBeneficiaryManager(db);const res=await mgr.importFromExcel('2024.xls');console.log(res);process.exit(0);})().catch(e=>{console.error(e);process.exit(1);});"`

------
https://chatgpt.com/codex/tasks/task_e_68a944f8396c8333947bdc7143c21163