### PR TITLE
feat: add care service list page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const DatabaseManager = require('./database/DatabaseManager');
 const ExcelImporter = require('./services/ExcelImporter');
 const FamilyServiceManager = require('./services/FamilyServiceManager');
+const CareBeneficiaryManager = require('./services/CareBeneficiaryManager');
 
 class App {
     constructor() {
@@ -10,6 +11,7 @@ class App {
         this.dbManager = new DatabaseManager();
         this.excelImporter = new ExcelImporter(this.dbManager);
         this.familyServiceManager = new FamilyServiceManager(this.dbManager);
+        this.careServiceManager = new CareBeneficiaryManager(this.dbManager);
         this.isInitialized = false;
         this.initPromise = null;
     }
@@ -393,6 +395,19 @@ class App {
                 return await this.familyServiceManager.getFilterOptions();
             } catch (error) {
                 console.error('获取家庭服务筛选选项失败:', error);
+                throw error;
+            }
+        });
+
+        // 获取关怀服务记录
+        ipcMain.handle('care-service:get-records', async (event, filters, pagination) => {
+            try {
+                if (!this.isInitialized) {
+                    await this.waitForInitialization();
+                }
+                return await this.careServiceManager.getRecords(filters, pagination);
+            } catch (error) {
+                console.error('获取关怀服务记录失败:', error);
                 throw error;
             }
         });

--- a/src/preload.js
+++ b/src/preload.js
@@ -28,6 +28,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
         exportExcel: (filters) => ipcRenderer.invoke('family-service:export-excel', filters),
         getFilterOptions: () => ipcRenderer.invoke('family-service:get-filter-options')
     },
+
+    // 关怀服务数据相关
+    careService: {
+        getRecords: (filters, pagination) => ipcRenderer.invoke('care-service:get-records', filters, pagination)
+    },
     
     // 通用调用方法（为了兼容性）
     invoke: (channel, ...args) => {
@@ -40,7 +45,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'family-service:get-record-by-id', 'family-service:create-record',
             'family-service:update-record', 'family-service:delete-record',
             'family-service:batch-delete-records', 'family-service:import-excel',
-            'family-service:export-excel', 'family-service:get-filter-options'
+            'family-service:export-excel', 'family-service:get-filter-options',
+            'care-service:get-records'
         ];
         
         if (allowedChannels.includes(channel)) {

--- a/src/renderer/care-service.html
+++ b/src/renderer/care-service.html
@@ -18,7 +18,22 @@
 <body class="bg-[var(--bg-primary)] text-[var(--text-primary)]">
   <main class="max-w-7xl mx-auto p-6">
     <h1 class="text-2xl font-bold mb-4">关怀服务列表</h1>
-    <p class="text-[var(--text-secondary)]">功能开发中，敬请期待。</p>
+    <div id="loading" class="text-[var(--text-secondary)]">加载中...</div>
+    <table id="careServiceTable" class="min-w-full divide-y divide-gray-200 hidden">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">序号</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">年月</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">服务中心</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">活动名称</th>
+          <th class="px-4 py-2 text-right text-sm font-medium text-gray-700">受益人次</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">备注</th>
+        </tr>
+      </thead>
+      <tbody id="careServiceTbody" class="divide-y divide-gray-100"></tbody>
+    </table>
+    <div id="emptyState" class="text-[var(--text-secondary)] hidden">暂无记录</div>
   </main>
+  <script src="js/care-service-table.js"></script>
 </body>
 </html>

--- a/src/renderer/js/care-service-table.js
+++ b/src/renderer/js/care-service-table.js
@@ -1,0 +1,35 @@
+(function () {
+  function $(id) { return document.getElementById(id); }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    const tbody = $('careServiceTbody');
+    const table = $('careServiceTable');
+    const loading = $('loading');
+    const emptyState = $('emptyState');
+
+    try {
+      const records = await window.electronAPI.careService.getRecords({}, { limit: 100 });
+      loading.classList.add('hidden');
+      if (!records || records.length === 0) {
+        emptyState.classList.remove('hidden');
+        return;
+      }
+      table.classList.remove('hidden');
+      records.forEach(row => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td class="px-4 py-2">${row.sequence_number || ''}</td>
+          <td class="px-4 py-2">${row.year ? `${row.year}-${String(row.month).padStart(2,'0')}` : ''}</td>
+          <td class="px-4 py-2">${row.service_center || ''}</td>
+          <td class="px-4 py-2">${row.activity_name || ''}</td>
+          <td class="px-4 py-2 text-right">${row.total_beneficiaries ?? ''}</td>
+          <td class="px-4 py-2">${row.notes || ''}</td>
+        `;
+        tbody.appendChild(tr);
+      });
+    } catch (error) {
+      console.error('加载关怀服务记录失败:', error);
+      loading.textContent = '加载失败';
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add care service list page and table script
- expose care-service IPC handlers
- expose care service API to renderer

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94ce79b688333925f6c7ad708e41e