### PR TITLE
chore: reference local Tailwind stylesheet

### DIFF
--- a/src/renderer/care-service-detail.html
+++ b/src/renderer/care-service-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>关怀服务详情 · 患儿入住信息管理系统</title>
   <meta name="color-scheme" content="light dark" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles/tailwind.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/src/renderer/care-service-statistics.html
+++ b/src/renderer/care-service-statistics.html
@@ -6,7 +6,7 @@
     <title>关怀服务统计分析 - 患儿入住信息管理系统</title>
     
     <!-- Core Styles - 统一设计系统 -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="styles/tailwind.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/renderer/care-service.html
+++ b/src/renderer/care-service.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>关怀服务列表 · 患儿入住信息管理系统</title>
   <meta name="color-scheme" content="light dark" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/renderer/dashboard.html
+++ b/src/renderer/dashboard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>概览仪表板 - 患儿入住信息管理系统</title>
     
+    <link rel="stylesheet" href="styles/tailwind.css">
     <!-- Core Styles -->
     <link rel="stylesheet" href="styles/medical-design-system.css">
     <link rel="stylesheet" href="styles/icon-system.css">

--- a/src/renderer/family-service.html
+++ b/src/renderer/family-service.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>家庭服务列表 · 患儿入住信息管理系统</title>
   <meta name="color-scheme" content="light dark" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles/tailwind.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>患儿入住信息管理系统</title>
   <meta name="color-scheme" content="light dark" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/renderer/patient-detail-enhanced.html
+++ b/src/renderer/patient-detail-enhanced.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>患者详情 - 患儿入住信息管理系统</title>
     
+    <link rel="stylesheet" href="styles/tailwind.css">
     <!-- Core Styles -->
     <link rel="stylesheet" href="styles/medical-design-system.css">
     <link rel="stylesheet" href="styles/icon-system.css">

--- a/src/renderer/patient-detail-redesigned.html
+++ b/src/renderer/patient-detail-redesigned.html
@@ -6,7 +6,7 @@
     <title>患者详情 - 患儿入住信息管理系统</title>
     
     <!-- Core Styles - 统一设计系统 -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="styles/tailwind.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/renderer/**/*.{html,js}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- replace Tailwind CDN script with link to a local stylesheet on every page
- add Tailwind config and base CSS source for future local builds

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b819ac4883339e4829d058e99538