### PR TITLE
feat: add reusable header component

### DIFF
--- a/src/renderer/care-service.html
+++ b/src/renderer/care-service.html
@@ -20,77 +20,41 @@
   <link rel="stylesheet" href="./styles/animations.css">
 </head>
 <body class="bg-[var(--bg-primary)] text-[var(--text-primary)] font-inter">
-  <!-- 顶部导航：与主页一致（sticky + 半透明 + 模糊） -->
-  <nav class="sticky top-0 z-30 backdrop-blur-md bg-white/80 border-b border-gray-200/50 shadow-sm">
-    <div class="max-w-7xl mx-auto px-6 py-4">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center space-x-4">
-          <button id="backBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500" title="返回主页" aria-label="返回主页">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
-              <path fill-rule="evenodd" d="M9.53 5.47a.75.75 0 010 1.06L4.81 11.25H21a.75.75 0 010 1.5H4.81l4.72 4.72a.75.75 0 11-1.06 1.06l-6-6a.75.75 0 010-1.06l6-6a.75.75 0 011.06 0z" clip-rule="evenodd"/>
-            </svg>
-          </button>
-          <div class="flex flex-col space-y-2">
-            <h1 class="text-2xl font-bold text-[var(--text-primary)]">关怀服务列表</h1>
-          </div>
-        </div>
-        <div class="flex items-center space-x-3">
-          <!-- 视图切换选项 -->
-          <div class="flex items-center space-x-2">
-            <span class="text-sm text-gray-500">视图:</span>
-            <div class="flex bg-gray-100 rounded-lg p-1">
-              <button id="gridViewBtn" class="px-3 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 transition-all" title="网格视图">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
-                </svg>
-              </button>
-              <button id="listViewBtn" class="px-3 py-1.5 text-sm font-medium text-gray-700 bg-white rounded-md shadow-sm transition-all" title="列表视图">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
-                </svg>
-              </button>
-            </div>
-          </div>
-          
-          <button id="exportBtn" class="bg-[var(--brand-secondary)] text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity flex items-center">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
-            </svg>
-            导出Excel
-          </button>
-          <a href="care-service-statistics.html" class="bg-purple-600 text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity flex items-center">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-            </svg>
-            统计分析
-          </a>
-          
-          <button id="importBtn" class="bg-[var(--brand-primary)] text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity flex items-center">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l3 3m0 0l-3 3m3-3H9"></path>
-            </svg>
-            导入Excel
-          </button>
-        </div>
+  <div data-component="header" data-title="关怀服务列表" data-back="true" data-breadcrumb="关怀服务列表">
+    <div class="flex items-center space-x-2">
+      <span class="text-sm text-gray-500">视图:</span>
+      <div class="flex bg-gray-100 rounded-lg p-1">
+        <button id="gridViewBtn" class="px-3 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 transition-all" title="网格视图">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
+          </svg>
+        </button>
+        <button id="listViewBtn" class="px-3 py-1.5 text-sm font-medium text-gray-700 bg-white rounded-md shadow-sm transition-all" title="列表视图">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
+          </svg>
+        </button>
       </div>
     </div>
-    <!-- 面包屑：与主页一致布局（分行显示） -->
-    <div class="hidden lg:flex max-w-7xl mx-auto px-6 py-2">
-      <nav aria-label="面包屑导航">
-        <ol class="flex items-center space-x-2 text-sm">
-          <li>
-            <a href="index.html" class="text-teal-600 hover:text-teal-700 font-medium transition-colors">主页</a>
-          </li>
-          <li class="text-gray-400">
-            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-            </svg>
-          </li>
-          <li class="text-gray-600 font-medium">关怀服务列表</li>
-        </ol>
-      </nav>
-    </div>
-  </nav>
+    <button id="exportBtn" class="bg-[var(--brand-secondary)] text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity flex items-center">
+      <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"></path>
+      </svg>
+      导出Excel
+    </button>
+    <a href="care-service-statistics.html" class="bg-purple-600 text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity flex items-center">
+      <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+      </svg>
+      统计分析
+    </a>
+    <button id="importBtn" class="bg-[var(--brand-primary)] text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity flex items-center">
+      <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l3 3m0 0l-3 3m3-3H9"></path>
+      </svg>
+      导入Excel
+    </button>
+  </div>
 
   <!-- Main Content -->
   <main class="max-w-7xl mx-auto p-6">
@@ -265,6 +229,7 @@
     </div>
   </main>
 
+  <script src="js/components/header.js"></script>
   <script src="js/care-service-table.js"></script>
 </body>
 </html>

--- a/src/renderer/components/header.html
+++ b/src/renderer/components/header.html
@@ -1,0 +1,46 @@
+<header class="sticky top-0 z-30 backdrop-blur-md bg-white/80 border-b border-gray-200/50 shadow-sm no-print" role="banner">
+  <div class="max-w-7xl mx-auto px-4 md:px-6 py-3 flex items-center justify-between">
+    <div class="flex items-center space-x-4">
+      <div class="flex items-center space-x-3">
+        <div class="w-10 h-10 bg-gradient-to-br from-teal-500 to-teal-600 rounded-xl flex items-center justify-center shadow-md">
+          <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+          </svg>
+        </div>
+        <div class="hidden sm:block">
+          <h1 data-header-title class="text-lg font-bold text-gray-900">系统</h1>
+          <p class="text-xs text-gray-500 leading-none">患儿入住信息管理</p>
+        </div>
+      </div>
+
+      <div class="flex items-center space-x-1 ml-4">
+        <button id="homeBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500" title="返回主页" aria-label="返回主页">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+            <path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z"/>
+            <path d="M12 5.432l8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 01-.75-.75v-4.5a.75.75 0 00-.75-.75h-3a.75.75 0 00-.75.75V21a.75.75 0 01-.75.75H5.625a1.875 1.875 0 01-1.875-1.875v-6.198a2.29 2.29 0 00.091-.086L12 5.43z"/>
+          </svg>
+        </button>
+        <button id="backBtn" data-back-btn class="inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500" title="返回" aria-label="返回" hidden>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+            <path fill-rule="evenodd" d="M9.53 5.47a.75.75 0 010 1.06L4.81 11.25H21a.75.75 0 010 1.5H4.81l4.72 4.72a.75.75 0 11-1.06 1.06l-6-6a.75.75 0 010-1.06l6-6a.75.75 0 011.06 0z" clip-rule="evenodd"/>
+          </svg>
+        </button>
+      </div>
+
+      <nav aria-label="面包屑导航" class="hidden lg:flex">
+        <ol class="flex items-center space-x-2 text-sm">
+          <li>
+            <button id="breadcrumbHome" class="text-teal-600 hover:text-teal-700 font-medium transition-colors">主页</button>
+          </li>
+          <li id="breadcrumbSeparator" class="text-gray-400 hidden">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+            </svg>
+          </li>
+          <li id="breadcrumbCurrent" class="text-gray-600 font-medium hidden"></li>
+        </ol>
+      </nav>
+    </div>
+    <div class="flex items-center space-x-3" data-header-actions></div>
+  </div>
+</header>

--- a/src/renderer/family-service.html
+++ b/src/renderer/family-service.html
@@ -379,54 +379,22 @@
   <!-- 无障碍跳转链接 -->
   <a href="#main" class="no-print sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-50 focus:bg-[var(--bg-secondary)] focus:px-3 focus:py-1.5 focus:rounded-md focus:shadow">跳到主要内容</a>
 
-  <!-- 顶部导航栏（与主页一致：半透明 + 固定） -->
-  <header class="sticky top-0 z-30 backdrop-blur-md bg-white/80 border-b border-gray-200/50 shadow-sm no-print" role="banner">
-    <div class="max-w-7xl mx-auto px-4 md:px-6 py-2.5 flex items-center gap-3">
-      <button id="backBtn" class="inline-flex items-center justify-center size-9 rounded-full hover:bg-[var(--bg-tertiary)] text-[var(--text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-color)]" title="返回主页" aria-label="返回主页">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5">
-          <path fill-rule="evenodd" d="M9.53 5.47a.75.75 0 010 1.06L4.81 11.25H21a.75.75 0 010 1.5H4.81l4.72 4.72a.75.75 0 11-1.06 1.06l-6-6a.75.75 0 010-1.06l6-6a.75.75 0 011.06 0z" clip-rule="evenodd"/>
+  <div data-component="header" data-title="家庭服务列表" data-back="true" data-breadcrumb="家庭服务列表">
+    <div class="hidden md:flex items-center gap-2 text-xs text-[var(--text-muted)]" aria-hidden="true">
+      <span class="kbd px-1.5 py-0.5 rounded">/</span><span>搜索</span>
+      <span class="kbd px-1.5 py-0.5 rounded">F</span><span>筛选</span>
+      <span class="kbd px-1.5 py-0.5 rounded">E</span><span>导出</span>
+    </div>
+    <div class="relative">
+      <button id="themeToggleBtn" class="inline-flex items-center gap-1.5 rounded-full border border-[var(--border-primary)] px-3 py-1.5 text-sm hover:bg-[var(--bg-tertiary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-color)]" aria-haspopup="menu" aria-expanded="false" aria-controls="themeMenu">
+        <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M15.5 2.5a1 1 0 0 0-2 0l-1 4-4-1a1 1 0 0 0-1 2l1 4-4 1a1 1 0 0 0 0 2l4 1-1 4a1 1 0 0 0 2 1l4-1 1 4a1 1 0 0 0 2 0l1-4 4 1a1 1 0 0 0 1-2l-1-4 1-4a1 1 0 0 0-2-1l-4 1-1-4Z"/>
         </svg>
+        <span>主题</span>
       </button>
-      <h1 class="text-[15px] md:text-lg font-bold tracking-tight text-[var(--brand-secondary)]">家庭服务列表</h1>
-
-      <div class="ml-auto flex items-center gap-2">
-        <!-- 快捷键提示 -->
-        <div class="hidden md:flex items-center gap-2 text-xs text-[var(--text-muted)]" aria-hidden="true">
-          <span class="kbd px-1.5 py-0.5 rounded">/</span><span>搜索</span>
-          <span class="kbd px-1.5 py-0.5 rounded">F</span><span>筛选</span>
-          <span class="kbd px-1.5 py-0.5 rounded">E</span><span>导出</span>
-        </div>
-
-        <!-- 主题切换 -->
-        <div class="relative">
-          <button id="themeToggleBtn" class="inline-flex items-center gap-1.5 rounded-full border border-[var(--border-primary)] px-3 py-1.5 text-sm hover:bg-[var(--bg-tertiary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring-color)]" aria-haspopup="menu" aria-expanded="false" aria-controls="themeMenu">
-            <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M15.5 2.5a1 1 0 0 0-2 0l-1 4-4-1a1 1 0 0 0-1 2l1 4-4 1a1 1 0 0 0 0 2l4 1-1 4a1 1 0 0 0 2 1l4-1 1 4a1 1 0 0 0 2 0l1-4 4 1a1 1 0 0 0 1-2l-1-4 1-4a1 1 0 0 0-2-1l-4 1-1-4Z"/>
-            </svg>
-            <span>主题</span>
-          </button>
-          <div id="themeMenu" class="absolute right-0 top-full mt-2 w-44 rounded-xl border border-[var(--border-primary)] bg-[var(--bg-secondary)] shadow-lg p-2 origin-top-right transition-transform duration-150 ease-out scale-95 opacity-0 pointer-events-none" role="menu" aria-label="主题选择" tabindex="-1"></div>
-        </div>
-      </div>
+      <div id="themeMenu" class="absolute right-0 top-full mt-2 w-44 rounded-xl border border-[var(--border-primary)] bg-[var(--bg-secondary)] shadow-lg p-2 origin-top-right transition-transform duration-150 ease-out scale-95 opacity-0 pointer-events-none" role="menu" aria-label="主题选择" tabindex="-1"></div>
     </div>
-
-    <!-- 面包屑导航（与主页风格一致） -->
-    <div class="hidden lg:flex max-w-7xl mx-auto px-4 md:px-6 py-2">
-      <nav aria-label="面包屑导航">
-        <ol class="flex items-center space-x-2 text-sm">
-          <li>
-            <a href="index.html" class="text-teal-600 hover:text-teal-700 font-medium transition-colors">主页</a>
-          </li>
-          <li class="text-gray-400">
-            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-            </svg>
-          </li>
-          <li class="text-gray-600 font-medium">家庭服务列表</li>
-        </ol>
-      </nav>
-    </div>
-  </header>
+  </div>
 
   <main id="main" class="max-w-7xl mx-auto px-4 md:px-6 py-6 md:py-8" role="main">
     <section id="listView" class="page active" aria-labelledby="listTitle">
@@ -615,6 +583,7 @@
   <script src="../config/resources.js"></script>
   <script src="../config/columns.js"></script>
   <script src="../config/filters.js"></script>
+  <script src="js/components/header.js"></script>
   <script src="js/components/resource-table.js"></script>
   <script src="js/family-service-table.js"></script>
 </body>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -190,108 +190,45 @@
 <body class="antialiased">
   <a href="#main" class="no-print sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-50 focus:bg-[var(--bg-secondary)] focus:px-3 focus:py-1.5 focus:rounded-md focus:shadow">跳到主要内容</a>
 
-  <!-- 顶部栏 -->
-  <header class="sticky top-0 z-30 backdrop-blur-md bg-white/80 border-b border-gray-200/50 shadow-sm no-print" role="banner">
-    <div class="max-w-7xl mx-auto px-4 md:px-6 py-3 flex items-center justify-between">
-      <!-- Logo和标题区 -->
-      <div class="flex items-center space-x-4">
-        <!-- Logo区域 -->
-        <div class="flex items-center space-x-3">
-          <div class="w-10 h-10 bg-gradient-to-br from-teal-500 to-teal-600 rounded-xl flex items-center justify-center shadow-md">
-            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
-            </svg>
-          </div>
-          <div class="hidden sm:block">
-            <h1 id="pageTitle" class="text-lg font-bold text-gray-900">小家管理系统</h1>
-            <p class="text-xs text-gray-500 leading-none">患儿入住信息管理</p>
-          </div>
-        </div>
-        
-        <!-- 导航按钮组 -->
-        <div class="flex items-center space-x-1 ml-4">
-          <button id="homeBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500" title="返回主页" aria-label="返回主页">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
-              <path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z"/>
-              <path d="M12 5.432l8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 01-.75-.75v-4.5a.75.75 0 00-.75-.75h-3a.75.75 0 00-.75.75V21a.75.75 0 01-.75.75H5.625a1.875 1.875 0 01-1.875-1.875v-6.198a2.29 2.29 0 00.091-.086L12 5.43z"/>
-            </svg>
-          </button>
-          <button id="backBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-gray-100 text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500" title="返回列表" aria-label="返回列表" hidden>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
-              <path fill-rule="evenodd" d="M9.53 5.47a.75.75 0 010 1.06L4.81 11.25H21a.75.75 0 010 1.5H4.81l4.72 4.72a.75.75 0 11-1.06 1.06l-6-6a.75.75 0 010-1.06l6-6a.75.75 0 011.06 0z" clip-rule="evenodd"/>
-            </svg>
-          </button>
-        </div>
-        
-        <!-- 面包屑导航 -->
-        <nav aria-label="面包屑导航" class="hidden lg:flex">
-          <ol class="flex items-center space-x-2 text-sm">
-            <li>
-              <button id="breadcrumbHome" class="text-teal-600 hover:text-teal-700 font-medium transition-colors" onclick="app.navigateTo('home')">主页</button>
-            </li>
-            <li id="breadcrumbSeparator" class="text-gray-400 hidden">
-              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-              </svg>
-            </li>
-            <li id="breadcrumbCurrent" class="text-gray-600 font-medium hidden"></li>
-          </ol>
-        </nav>
-      </div>
-
-      <!-- 操作按钮组 -->
-      <div class="flex items-center space-x-3">
-        <!-- 快捷键提示 -->
-        <div class="hidden lg:flex items-center space-x-2 text-xs text-gray-500 bg-gray-50 px-3 py-1.5 rounded-lg" aria-hidden="true">
-          <kbd class="px-2 py-1 bg-white border border-gray-200 rounded text-xs font-mono shadow-sm">⌘</kbd>
-          <span>+</span>
-          <kbd class="px-2 py-1 bg-white border border-gray-200 rounded text-xs font-mono shadow-sm">K</kbd>
-          <span>搜索</span>
-        </div>
-        
-        <!-- 主要操作按钮 -->
-        <button id="importBtn" class="inline-flex items-center space-x-2 px-4 py-2 bg-gradient-to-r from-teal-500 to-teal-600 text-white rounded-lg hover:from-teal-600 hover:to-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 transition-all shadow-sm hover:shadow-md">
+  <div data-component="header" data-title="小家管理系统">
+    <div class="hidden lg:flex items-center space-x-2 text-xs text-gray-500 bg-gray-50 px-3 py-1.5 rounded-lg" aria-hidden="true">
+      <kbd class="px-2 py-1 bg-white border border-gray-200 rounded text-xs font-mono shadow-sm">⌘</kbd>
+      <span>+</span>
+      <kbd class="px-2 py-1 bg-white border border-gray-200 rounded text-xs font-mono shadow-sm">K</kbd>
+      <span>搜索</span>
+    </div>
+    <button id="importBtn" class="inline-flex items-center space-x-2 px-4 py-2 bg-gradient-to-r from-teal-500 to-teal-600 text-white rounded-lg hover:from-teal-600 hover:to-teal-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 transition-all shadow-sm hover:shadow-md">
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+        <polyline points="7,10 12,15 17,10"/>
+        <line x1="12" y1="15" x2="12" y2="3"/>
+      </svg>
+      <span class="hidden sm:inline">导入Excel</span>
+      <span class="sm:hidden">导入</span>
+    </button>
+    <button id="exportBtn" class="inline-flex items-center space-x-2 px-3 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg hover:bg-gray-50 hover:border-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 transition-all" title="导出数据">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+      </svg>
+      <span class="hidden md:inline">导出</span>
+    </button>
+    <div class="flex items-center space-x-1">
+      <button id="settingsBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-600 transition-colors" title="系统设置">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+      </button>
+      <div class="relative">
+        <button id="themeToggleBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-600 transition-colors" aria-haspopup="menu" aria-expanded="false" aria-controls="themeMenu" title="切换主题">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-            <polyline points="7,10 12,15 17,10"/>
-            <line x1="12" y1="15" x2="12" y2="3"/>
+            <path d="M15.5 2.5a1 1 0 0 0-2 0l-1 4-4-1a1 1 0 0 0-1 2l1 4-4 1a1 1 0 0 0 0 2l4 1-1 4a1 1 0 0 0 2 1l4-1 1 4a1 1 0 0 0 2 0l1-4 4 1a1 1 0 0 0 1-2l-1-4 1-4a1 1 0 0 0-2-1l-4 1-1-4Z"/>
           </svg>
-          <span class="hidden sm:inline">导入Excel</span>
-          <span class="sm:hidden">导入</span>
         </button>
-
-        <!-- 次要操作按钮 -->
-        <button id="exportBtn" class="inline-flex items-center space-x-2 px-3 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg hover:bg-gray-50 hover:border-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 transition-all" title="导出数据">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-          </svg>
-          <span class="hidden md:inline">导出</span>
-        </button>
-
-        <!-- 设置和主题按钮 -->
-        <div class="flex items-center space-x-1">
-          <button id="settingsBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-600 transition-colors" title="系统设置">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
-          </button>
-          
-          <!-- 主题切换下拉菜单 -->
-          <div class="relative">
-            <button id="themeToggleBtn" class="inline-flex items-center justify-center w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-600 transition-colors" aria-haspopup="menu" aria-expanded="false" aria-controls="themeMenu" title="切换主题">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M15.5 2.5a1 1 0 0 0-2 0l-1 4-4-1a1 1 0 0 0-1 2l1 4-4 1a1 1 0 0 0 0 2l4 1-1 4a1 1 0 0 0 2 1l4-1 1 4a1 1 0 0 0 2 0l1-4 4 1a1 1 0 0 0 1-2l-1-4 1-4a1 1 0 0 0-2-1l-4 1-1-4Z"/>
-              </svg>
-            </button>
-            <div id="themeMenu" class="absolute right-0 top-full mt-2 w-48 bg-white rounded-xl border border-gray-200 shadow-lg p-2 origin-top-right transition-all duration-200 ease-out scale-95 opacity-0 pointer-events-none" role="menu" aria-label="主题选择" tabindex="-1">
-              <!-- 主题菜单项将由JavaScript动态生成 -->
-            </div>
-          </div>
-        </div>
+        <div id="themeMenu" class="absolute right-0 top-full mt-2 w-48 bg-white rounded-xl border border-gray-200 shadow-lg p-2 origin-top-right transition-all duration-200 ease-out scale-95 opacity-0 pointer-events-none" role="menu" aria-label="主题选择" tabindex="-1"></div>
       </div>
     </div>
-  </header>
+  </div>
 
   <main id="main" class="max-w-7xl mx-auto px-4 md:px-6 py-6 md:py-8" role="main">
     <!-- 加载提示 -->
@@ -1278,6 +1215,7 @@
   <script src="../config/columns.js"></script>
   <script src="../config/filters.js"></script>
   <script src="../viewmodels/FamilyServiceViewModel.js"></script>
+  <script src="./js/components/header.js"></script>
   <script src="./js/icon-library.js"></script>
   <script src="./js/enhanced-search.js"></script>
   <script src="./js/enhanced-upload.js"></script>

--- a/src/renderer/js/components/header.js
+++ b/src/renderer/js/components/header.js
@@ -1,0 +1,39 @@
+(function() {
+  const load = el => {
+    const custom = Array.from(el.children);
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', 'components/header.html', false);
+    xhr.send(null);
+    if (xhr.status !== 200) return;
+    el.innerHTML = xhr.responseText;
+
+    const title = el.dataset.title;
+    const titleEl = el.querySelector('[data-header-title]');
+    if (title && titleEl) titleEl.textContent = title;
+
+    const backBtn = el.querySelector('[data-back-btn]');
+    if (backBtn) {
+      if (el.dataset.back === 'true') {
+        backBtn.removeAttribute('hidden');
+      } else {
+        backBtn.setAttribute('hidden', '');
+      }
+    }
+
+    const breadcrumb = el.dataset.breadcrumb;
+    if (breadcrumb) {
+      const sep = el.querySelector('#breadcrumbSeparator');
+      const cur = el.querySelector('#breadcrumbCurrent');
+      if (sep && cur) {
+        sep.classList.remove('hidden');
+        cur.textContent = breadcrumb;
+        cur.classList.remove('hidden');
+      }
+    }
+
+    const actions = el.querySelector('[data-header-actions]');
+    custom.forEach(node => actions.appendChild(node));
+  };
+
+  document.querySelectorAll('[data-component="header"]').forEach(load);
+})();


### PR DESCRIPTION
## Summary
- add shared header with navigation and breadcrumb
- load header via script using data attributes for title and back button
- update index, care-service and family-service pages to use component

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b93f775883338b7a31554cfc5a79