### PR TITLE
fix(importer): track total and failed rows in family service import

### DIFF
--- a/src/services/FamilyServiceImporter.js
+++ b/src/services/FamilyServiceImporter.js
@@ -133,7 +133,8 @@ class FamilyServiceImporter extends ExcelImporter {
                 // 处理数据行（从第3行开始，索引2）
                 for (let i = 2; i < rawData.length; i++) {
                     const row = rawData[i];
-                    
+                    result.totalRows++;
+
                     try {
                         if (!row || row.length === 0) continue;
                         
@@ -168,6 +169,7 @@ class FamilyServiceImporter extends ExcelImporter {
 
                         if (existingRecord && !options.allowDuplicates) {
                             result.duplicateCount++;
+                            result.errorCount++;
                             continue;
                         }
 

--- a/src/services/__tests__/FamilyServiceImporter.test.js
+++ b/src/services/__tests__/FamilyServiceImporter.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const XLSX = require('xlsx');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-importer-test-'));
+const mockElectron = { app: { getPath: () => tmpDir } };
+jest.mock('electron', () => mockElectron);
+
+const DatabaseManager = require('../../database/DatabaseManager');
+const FamilyServiceImporter = require('../FamilyServiceImporter');
+
+describe('FamilyServiceImporter import counts', () => {
+  let dbManager;
+  let importer;
+  let filePath;
+
+  beforeAll(async () => {
+    dbManager = new DatabaseManager();
+    await dbManager.initialize();
+    importer = new FamilyServiceImporter(dbManager);
+
+    const data = [
+      ['标题'],
+      ['序号','年月','家庭数量','入住人数','入住天数','住宿人次','关怀服务人次','志愿者陪伴服务人次','服务总人次','备注','累计入住天数','累计服务人次'],
+      ['1', 45292, 1,1,1,1,1,1,2,'',1,2],
+      ['2', 'invalid', 0,0,0,0,0,0,0,'',0,0],
+      ['3', 45292, 3,3,3,3,3,3,6,'',3,6]
+    ];
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.aoa_to_sheet(data);
+    XLSX.utils.book_append_sheet(wb, ws, '家庭服务');
+    filePath = path.join(tmpDir, 'test.xlsx');
+    XLSX.writeFile(wb, filePath);
+  });
+
+  afterAll(async () => {
+    if (dbManager && dbManager.db) {
+      await new Promise(resolve => dbManager.db.close(resolve));
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('counts reflect processing outcomes', async () => {
+    const result = await importer.importFamilyServiceData(filePath);
+    expect(result.totalRows).toBe(3);
+    expect(result.successCount).toBe(1);
+    expect(result.errorCount).toBe(2);
+    expect(result.duplicateCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- count every processed row during family service import
- mark duplicate rows as errors to keep counts consistent
- cover import statistics with a new Jest test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aacc2ee4508333ab6a806388e4f47c