### PR TITLE
feat(ui): unify home card names and layout

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -378,7 +378,7 @@
             <div class="flex-1 h-px bg-gradient-to-r from-[var(--border-primary)] to-transparent"></div>
           </div>
           
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
             <!-- 入住信息管理 -->
             <div class="card group cursor-pointer" onclick="app.navigateToPatientList()">
               <div class="card-header-bg p-6">
@@ -389,7 +389,7 @@
                     </svg>
                   </div>
                   <div>
-                    <h4 class="text-lg font-semibold text-white">入住信息</h4>
+                    <h4 class="text-lg font-semibold text-white">入住信息管理</h4>
                     <p class="text-white/80 text-sm">患儿档案 · 入住记录</p>
                   </div>
                 </div>
@@ -434,7 +434,7 @@
                     </svg>
                   </div>
                   <div>
-                    <h4 class="text-lg font-semibold text-white">家庭服务</h4>
+                    <h4 class="text-lg font-semibold text-white">家庭服务管理</h4>
                     <p class="text-white/80 text-sm">服务记录 · 统计分析</p>
                   </div>
                 </div>
@@ -468,22 +468,7 @@
                 </div>
               </div>
             </div>
-          </div>
-        </div>
 
-        <!-- 扩展服务模块 -->
-        <div>
-          <div class="flex items-center gap-3 mb-6">
-            <div class="w-8 h-8 bg-gradient-to-br from-orange-500 to-orange-600 rounded-lg flex items-center justify-center">
-              <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
-              </svg>
-            </div>
-            <h3 class="text-xl font-bold text-[var(--text-primary)]">扩展服务</h3>
-            <div class="flex-1 h-px bg-gradient-to-r from-[var(--border-primary)] to-transparent"></div>
-          </div>
-          
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <!-- 关怀服务管理 -->
             <div class="card group cursor-pointer" onclick="app.navigateToCareService()">
               <div class="card-header-bg p-6">
@@ -494,7 +479,7 @@
                     </svg>
                   </div>
                   <div>
-                    <h4 class="text-lg font-semibold text-white">关怀服务</h4>
+                    <h4 class="text-lg font-semibold text-white">关怀服务管理</h4>
                     <p class="text-white/80 text-sm">服务记录 · 关怀统计</p>
                   </div>
                 </div>
@@ -528,22 +513,9 @@
                 </div>
               </div>
             </div>
-
-            <!-- 预留扩展位置 -->
-            <div class="card group border-2 border-dashed border-[var(--border-primary)] bg-[var(--bg-tertiary)]/30 cursor-default">
-              <div class="p-6 text-center">
-                <div class="w-12 h-12 bg-[var(--text-muted)]/20 rounded-xl flex items-center justify-center mx-auto mb-4">
-                  <svg class="w-6 h-6 text-[var(--text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
-                  </svg>
-                </div>
-                <h4 class="text-lg font-semibold text-[var(--text-muted)] mb-2">更多功能</h4>
-                <p class="text-[var(--text-muted)] text-sm mb-4">更多服务模块正在规划中</p>
-                <span class="px-3 py-1 bg-[var(--text-muted)]/10 text-[var(--text-muted)] text-xs rounded-full">敬请期待</span>
-              </div>
-            </div>
           </div>
         </div>
+
       </div>
 
       <!-- 快速操作区域 -->
@@ -714,7 +686,7 @@
               统计分析中心
             </h3>
             
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
               <!-- 入住信息统计 -->
               <div class="group cursor-pointer" onclick="app.navigateToStatistics()">
                 <div class="card-header-bg p-6 rounded-t-xl">
@@ -725,7 +697,7 @@
                       </svg>
                     </div>
                     <div>
-                      <h4 class="text-lg font-semibold text-white">入住信息统计</h4>
+                      <h4 class="text-lg font-semibold text-white">入住信息分析</h4>
                       <p class="text-white/80 text-sm">患儿数据 · 入住分析</p>
                     </div>
                   </div>
@@ -741,7 +713,7 @@
                 </div>
               </div>
 
-              <!-- 家庭服务统计 -->
+              <!-- 家庭服务分析 -->
               <div class="group cursor-pointer" onclick="app.navigateToFamilyServiceStatistics()">
                 <div class="card-header-bg p-6 rounded-t-xl">
                   <div class="flex items-center gap-4">
@@ -751,7 +723,7 @@
                       </svg>
                     </div>
                     <div>
-                      <h4 class="text-lg font-semibold text-white">家庭服务统计</h4>
+                      <h4 class="text-lg font-semibold text-white">家庭服务分析</h4>
                       <p class="text-white/80 text-sm">服务记录 · 时间分析</p>
                     </div>
                   </div>
@@ -766,8 +738,34 @@
                   </div>
                 </div>
               </div>
+
+              <!-- 关怀服务分析 -->
+              <div class="group cursor-pointer" onclick="app.navigateToCareServiceStatistics()">
+                <div class="card-header-bg p-6 rounded-t-xl">
+                  <div class="flex items-center gap-4">
+                    <div class="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center">
+                      <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+                      </svg>
+                    </div>
+                    <div>
+                      <h4 class="text-lg font-semibold text-white">关怀服务分析</h4>
+                      <p class="text-white/80 text-sm">活动记录 · 受益统计</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="bg-white rounded-b-xl border border-t-0 border-[var(--border-primary)] p-6 group-hover:bg-[var(--bg-tertiary)] transition-colors">
+                  <p class="text-[var(--text-secondary)] mb-4">查看关怀活动、志愿者参与及受益人统计分析</p>
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm text-[var(--brand-primary)] font-medium">查看关怀分析</span>
+                    <svg class="w-4 h-4 text-[var(--brand-primary)] transform group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                    </svg>
+                  </div>
+                </div>
+              </div>
             </div>
-            
+
             <!-- 统计功能说明 -->
             <div class="mt-6 p-4 bg-[var(--bg-tertiary)] rounded-xl">
               <div class="flex items-start gap-3">


### PR DESCRIPTION
## Summary
- rename home page cards to 入住信息管理/分析, 家庭服务管理/分析, 关怀服务管理/分析
- display management and analysis cards in three-column grids for a cleaner layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abb75a12dc8333a6dbaacfe6d2b0f3